### PR TITLE
fix build, test, example on zig 0.10-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 zig-cache/
 /build/
 /build-*/
+zig-out/
+example

--- a/src/example.zig
+++ b/src/example.zig
@@ -61,9 +61,9 @@ pub fn main() void {
 
     // switch on the content if you don't already know the type
     switch (geojson.content) {
-        .feature => |feature| std.debug.warn("It's a Feature!\n", .{}),
-        .feature_collection => |features| std.debug.warn("It's a FeatureCollection!\n", .{}),
-        .geometry => |geometry| std.debug.warn("It's a Geometry!\n", .{}),
+        .feature => std.debug.warn("It's a Feature!\n", .{}),
+        .feature_collection => std.debug.warn("It's a FeatureCollection!\n", .{}),
+        .geometry => std.debug.warn("It's a Geometry!\n", .{}),
     }
 
     // there are helper methods `featureCollection()`, `feature()`, and `geometry()`, returning optionals

--- a/src/example.zig
+++ b/src/example.zig
@@ -54,32 +54,32 @@ pub fn main() void {
     ;
 
     var geojson = Parser.parse(json, std.testing.allocator) catch |err| {
-        std.debug.warn("Could not parse geojson! {}", .{err});
+        std.log.warn("Could not parse geojson! {}", .{err});
         return;
     };
     defer geojson.deinit();
 
     // switch on the content if you don't already know the type
     switch (geojson.content) {
-        .feature => std.debug.warn("It's a Feature!\n", .{}),
-        .feature_collection => std.debug.warn("It's a FeatureCollection!\n", .{}),
-        .geometry => std.debug.warn("It's a Geometry!\n", .{}),
+        .feature => std.log.warn("It's a Feature!\n", .{}),
+        .feature_collection => std.log.warn("It's a FeatureCollection!\n", .{}),
+        .geometry => std.log.warn("It's a Geometry!\n", .{}),
     }
 
     // there are helper methods `featureCollection()`, `feature()`, and `geometry()`, returning optionals
     if (geojson.featureCollection()) |collection| {
-        std.debug.warn("FeatureCollection contains {} features\n", .{collection.len});
+        std.log.warn("FeatureCollection contains {} features\n", .{collection.len});
 
         for (collection) |feature, idx| {
-            std.debug.warn("{}: It's a {s} => ", .{ idx, @tagName(feature.geometry) });
+            std.log.warn("{}: It's a {s} => ", .{ idx, @tagName(feature.geometry) });
             switch (feature.geometry) {
-                .point => |value| std.debug.warn("[{d}, {d}]\n", .{ value[0], value[1] }),
-                .multi_point => |value| std.debug.warn("containing {} points\n", .{value.len}),
-                .line_string => |value| std.debug.warn("containing {} points\n", .{value.len}),
-                .multi_line_string => |value| std.debug.warn("containing {} lineStrings\n", .{value.len}),
-                .polygon => |value| std.debug.warn("containing {} rings\n", .{value.len}),
-                .multi_polygon => |value| std.debug.warn("containing {} polygons\n", .{value.len}),
-                .geometry_collection => |value| std.debug.warn("containing {} geometries\n", .{value.len}),
+                .point => |value| std.log.warn("[{d}, {d}]\n", .{ value[0], value[1] }),
+                .multi_point => |value| std.log.warn("containing {} points\n", .{value.len}),
+                .line_string => |value| std.log.warn("containing {} points\n", .{value.len}),
+                .multi_line_string => |value| std.log.warn("containing {} lineStrings\n", .{value.len}),
+                .polygon => |value| std.log.warn("containing {} rings\n", .{value.len}),
+                .multi_polygon => |value| std.log.warn("containing {} polygons\n", .{value.len}),
+                .geometry_collection => |value| std.log.warn("containing {} geometries\n", .{value.len}),
                 .@"null" => continue,
             }
         }
@@ -88,12 +88,12 @@ pub fn main() void {
         const feature = collection[0];
         if (feature.properties) |properties| {
             if (properties.get("prop0")) |value| {
-                std.debug.warn("Property: 'prop0' => {}\n", .{value});
+                std.log.warn("Property: 'prop0' => {}\n", .{value});
             }
         }
 
         // or unsafe
         const value = collection[1].properties.?.get("prop1").?;
-        std.debug.warn("Property: 'prop1' => {}\n", .{value});
+        std.log.warn("Property: 'prop1' => {}\n", .{value});
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -194,7 +194,7 @@ pub const Parser = struct {
         allocator: std.mem.Allocator,
     ) !Identifier {
         return switch (value) {
-            .String => |s| Identifier{ .string = try std.mem.dupe(allocator, u8, s) },
+            .String => |s| Identifier{ .string = try allocator.dupe(u8, s) },
             .Integer => |i| Identifier{ .int = i },
             .Float => |f| Identifier{ .float = f },
             else => error.InvalidGeoJson,
@@ -217,8 +217,8 @@ pub const Parser = struct {
             .Bool => |b| return PropertyValue{ .bool = b },
             .Integer => |i| return PropertyValue{ .int = i },
             .Float => |f| return PropertyValue{ .float = f },
-            .String => |s| return PropertyValue{ .string = try std.mem.dupe(allocator, u8, s) },
-            .NumberString => |s| return PropertyValue{ .string = try std.mem.dupe(allocator, u8, s) },
+            .String => |s| return PropertyValue{ .string = try allocator.dupe(u8, s) },
+            .NumberString => |s| return PropertyValue{ .string = try allocator.dupe(u8, s) },
             .Array => |arr| {
                 const array = try allocator.alloc(PropertyValue, arr.items.len);
                 for (arr.items) |item, idx| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -161,7 +161,7 @@ test "geometries" {
         \\}
     ;
 
-    var geojson = try Parser.parse(json, std.heap.page_allocator);
+    var geojson = try Parser.parse(json, std.testing.allocator);
     defer geojson.deinit();
 
     const bbox = BBox{ .min = .{ 100.0, 0.0 }, .max = .{ 103.0, 3.0 } };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const zig_geojson = @import("main.zig");
 const Parser = zig_geojson.Parser;
-const BBox = zig_geojson.Parser;
+const BBox = zig_geojson.BBox;
 const Point = zig_geojson.Point;
 
 test "simple feature" {


### PR DESCRIPTION
@SebastianKeller 👋🏽 
I am very new to Zig but have a goal of creating/improving the geospatial and data-science packages for  Zig! I am using the main branch of Zig - currently 0.10-dev.

The changes to allocators are described here:
https://pithlessly.github.io/allocgate.html

Using this fix branch, it now works for me like:

```
$ zig version
0.10.0-dev.2130+e7ac05e88

$ zig build test
All 3 tests passed.

$ zig build-exe src/example.zig 

$ ./example 
warning: It's a FeatureCollection!

warning: FeatureCollection contains 3 features

warning: 0: It's a point => 
warning: [102, 0.5]

warning: 1: It's a line_string => 
warning: containing 4 points

warning: 2: It's a polygon => 
warning: containing 1 rings

warning: Property: 'prop0' => PropertyValue{ .string = { 118, 97, 108, 117, 101, 48 } }

warning: Property: 'prop1' => PropertyValue{ .float = 0.0e+00 }
```
